### PR TITLE
Add route resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add RouteResolver to resolve platform.sh routes into their environment URLs
 
 ## [1.0.2] - 2017-09-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Add RouteResolver to resolve platform.sh routes into their environment URLs
+- Resolve routes.yaml route key like domain into their environment domain
 
 ## [1.0.2] - 2017-09-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add RouteResolver to resolve platform.sh routes into their environment URLs
 - Resolve routes.yaml route key like domain into their environment domain
+- Read local .platform/routes.yaml if no $PLATFORM_ROUTES is available (upstream routes only)
 
 ## [1.0.2] - 2017-09-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
 ## [1.0.2] - 2017-09-19
 ### Changed
 - Change license to GPL-3.0+, because we include TYPO3 code in future

--- a/DependencyInjection/BartacusPlatformshExtension.php
+++ b/DependencyInjection/BartacusPlatformshExtension.php
@@ -27,6 +27,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Yaml\Yaml;
 
 class BartacusPlatformshExtension extends Extension
 {
@@ -38,5 +39,25 @@ class BartacusPlatformshExtension extends Extension
         );
 
         $loader->load('services.xml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $this->registerPlatformRoutesConfig($container, $config);
+    }
+
+    private function registerPlatformRoutesConfig(ContainerBuilder $container, array $config): void
+    {
+        $rootDir = $container->getParameter('kernel.project_dir');
+        $platformRoutesConfigPath = $rootDir.'/'.$config['platform_routes_path'];
+
+        if ($container->fileExists($platformRoutesConfigPath)) {
+            $platformRoutesConfig = \file_get_contents($platformRoutesConfigPath);
+            $platformRoutesConfig = Yaml::parse($platformRoutesConfig);
+
+            $container->setParameter('bartacus_platformsh.platform_routes_config', $platformRoutesConfig);
+        } else {
+            $container->setParameter('bartacus_platformsh.platform_routes_config', null);
+        }
     }
 }

--- a/DependencyInjection/BartacusPlatformshExtension.php
+++ b/DependencyInjection/BartacusPlatformshExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class BartacusPlatformshExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new XmlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'/../Resources/config')
+        );
+
+        $loader->load('services.xml');
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('bartacus_platformsh');
+
+        $rootNode
+            ->children()
+                ->scalarNode('platform_routes_path')
+                    ->defaultValue('.platform/routes.yaml')
+                    ->info('The path to the routes.yaml file with ".local_url" keys relative to %kernel.project_dir%')
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/Exception/PlatformshBundleException.php
+++ b/Exception/PlatformshBundleException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Exception;
+
+/**
+ * Marker interface to catch all exceptions from this bundle.
+ */
+interface PlatformshBundleException
+{
+}

--- a/Exception/RouteDomainNotFound.php
+++ b/Exception/RouteDomainNotFound.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Exception;
+
+/**
+ * Exception thrown when a route matching a given domain does not exist.
+ */
+class RouteDomainNotFound extends \InvalidArgumentException implements PlatformshBundleException
+{
+}

--- a/Exception/RouteNotFound.php
+++ b/Exception/RouteNotFound.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Exception;
+
+/**
+ * Exception thrown when a route does not exist.
+ */
+class RouteNotFound extends \InvalidArgumentException implements PlatformshBundleException
+{
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="false" />
+
+        <service id="Platformsh\ConfigReader\Config" public="true" />
+
+        <service id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory">
+            <argument type="service" id="Platformsh\ConfigReader\Config" />
+        </service>
+
+        <service id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolver" public="true">
+            <factory service="Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory" method="createResolver" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,7 @@
 
         <service id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory">
             <argument type="service" id="Platformsh\ConfigReader\Config" />
+            <argument>%bartacus_platformsh.platform_routes_config%</argument>
         </service>
 
         <service id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolver" public="true">

--- a/Resources/fixtures/routes.yaml
+++ b/Resources/fixtures/routes.yaml
@@ -1,0 +1,4 @@
+"https://{default}/":
+    .local_url: "https://dev-project.test/"
+    type: upstream
+    upstream: "app:http"

--- a/Resources/fixtures/routes_with_no_local.yaml
+++ b/Resources/fixtures/routes_with_no_local.yaml
@@ -1,0 +1,8 @@
+"https://{default}/":
+    .local_url: "https://dev-project.test/"
+    type: upstream
+    upstream: "app:http"
+
+"https://api.{default}/":
+    type: upstream
+    upstream: "api:http"

--- a/Route/LocalUpstreamRoute.php
+++ b/Route/LocalUpstreamRoute.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\Url\Url;
+use Webmozart\Assert\Assert;
+
+final class LocalUpstreamRoute implements UpstreamRoute
+{
+    /**
+     * @var UriInterface
+     */
+    private $originalUrl;
+
+    /**
+     * @var UriInterface
+     */
+    private $resolvedUrl;
+
+    /**
+     * @var string
+     */
+    private $upstream;
+
+    public function __construct(string $originalUrl, $route)
+    {
+        Assert::keyExists($route, 'type', 'It seems $route is not a valid route');
+        Assert::same($route['type'], 'upstream', '$route is not an upstream route, wrong type: '.$route['type']);
+
+        $this->originalUrl = Url::fromString($originalUrl);
+
+        Assert::keyExists($route, '.local_url', 'Missing key .local_url in $route.');
+        $this->resolvedUrl = Url::fromString($route['.local_url']);
+
+        Assert::keyExists($route, 'upstream', 'Missing key upstream in $route.');
+        $this->upstream = \preg_replace('/(\w*):http/', '\1', $route['upstream']);
+    }
+
+    public function originalUrl(): UriInterface
+    {
+        return $this->originalUrl;
+    }
+
+    public function resolvedUrl(): UriInterface
+    {
+        return $this->resolvedUrl;
+    }
+
+    public function upstream(): string
+    {
+        return $this->upstream;
+    }
+}

--- a/Route/PlatformshRedirectRoute.php
+++ b/Route/PlatformshRedirectRoute.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\Url\Url;
+use Webmozart\Assert\Assert;
+
+final class PlatformshRedirectRoute implements RedirectRoute
+{
+    /**
+     * @var UriInterface
+     */
+    private $originalUrl;
+
+    /**
+     * @var UriInterface
+     */
+    private $resolvedUrl;
+
+    /**
+     * @var string
+     */
+    private $to;
+
+    public function __construct(string $resolvedUrl, array $route)
+    {
+        Assert::keyExists($route, 'type', 'It seems $route is not a valid route');
+        Assert::same($route['type'], 'redirect', '$route is not an redirect route, wrong type: '.$route['type']);
+
+        $this->resolvedUrl = Url::fromString($resolvedUrl);
+
+        Assert::keyExists($route, 'original_url', 'Missing key original_url in $route .');
+        $this->originalUrl = Url::fromString($route['original_url']);
+
+        Assert::keyExists($route, 'to', 'Missing key to in $route.');
+        $this->to = Url::fromString($route['to']);
+    }
+
+    public function originalUrl(): UriInterface
+    {
+        return $this->originalUrl;
+    }
+
+    public function resolvedUrl(): UriInterface
+    {
+        return $this->resolvedUrl;
+    }
+
+    public function to(): UriInterface
+    {
+        return $this->to;
+    }
+}

--- a/Route/PlatformshUpstreamRoute.php
+++ b/Route/PlatformshUpstreamRoute.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\Url\Url;
+use Webmozart\Assert\Assert;
+
+final class PlatformshUpstreamRoute implements UpstreamRoute
+{
+    /**
+     * @var UriInterface
+     */
+    private $originalUrl;
+
+    /**
+     * @var UriInterface
+     */
+    private $resolvedUrl;
+
+    /**
+     * @var string
+     */
+    private $upstream;
+
+    public function __construct(string $resolvedUrl, array $route)
+    {
+        Assert::keyExists($route, 'type', 'It seems $route is not a valid route');
+        Assert::same($route['type'], 'upstream', '$route is not an upstream route, wrong type: '.$route['type']);
+
+        $this->resolvedUrl = Url::fromString($resolvedUrl);
+
+        Assert::keyExists($route, 'original_url', 'Missing key original_url in $route.');
+        $this->originalUrl = Url::fromString($route['original_url']);
+
+        Assert::keyExists($route, 'upstream', 'Missing key upstream in $route.');
+        $this->upstream = $route['upstream'];
+    }
+
+    public function originalUrl(): UriInterface
+    {
+        return $this->originalUrl;
+    }
+
+    public function resolvedUrl(): UriInterface
+    {
+        return $this->resolvedUrl;
+    }
+
+    public function upstream(): string
+    {
+        return $this->upstream;
+    }
+}

--- a/Route/RedirectRoute.php
+++ b/Route/RedirectRoute.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+use Psr\Http\Message\UriInterface;
+
+interface RedirectRoute extends RouteDefinition
+{
+    /**
+     * The target of the redirect.
+     */
+    public function to(): UriInterface;
+}

--- a/Route/RouteCollection.php
+++ b/Route/RouteCollection.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+final class RouteCollection implements \IteratorAggregate
+{
+    /**
+     * @var RouteDefinition[]
+     */
+    private $routes;
+
+    public function __construct(RouteDefinition ...$routes)
+    {
+        $this->routes = $routes;
+    }
+
+    /**
+     * @return RouteDefinition[]
+     */
+    public function getIterator(): iterable
+    {
+        $routes = [];
+        foreach ($this->routes as $route) {
+            $routes[] = clone $route;
+        }
+
+        return new \ArrayIterator($routes);
+    }
+
+    public function getUpstreamRoutes(): self
+    {
+        $routes = [];
+        foreach ($this->routes as $route) {
+            if ($route instanceof UpstreamRoute) {
+                $routes[] = clone $route;
+            }
+        }
+
+        return new self(...$routes);
+    }
+
+    public function getRedirectRoutes(): self
+    {
+        $routes = [];
+        foreach ($this->routes as $route) {
+            if ($route instanceof RedirectRoute) {
+                $routes[] = clone $route;
+            }
+        }
+
+        return new self(...$routes);
+    }
+}

--- a/Route/RouteDefinition.php
+++ b/Route/RouteDefinition.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+use Psr\Http\Message\UriInterface;
+
+interface RouteDefinition
+{
+    /**
+     * Get the original url, the route key from routes.yaml.
+     */
+    public function originalUrl(): UriInterface;
+
+    /**
+     * Get the resolved url, either a productive domain or a mangled environment url.
+     */
+    public function resolvedUrl(): UriInterface;
+}

--- a/Route/RouteResolver.php
+++ b/Route/RouteResolver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+use Bartacus\Bundle\PlatformshBundle\Exception\RouteNotFound;
+use Spatie\Url\Url;
+
+final class RouteResolver
+{
+    /**
+     * @var RouteCollection
+     */
+    private $routes;
+
+    public function __construct(RouteCollection $routes)
+    {
+        $this->routes = $routes;
+    }
+
+    /**
+     * Resolve an original url/route key from routes.yaml to a route object.
+     *
+     * @throws RouteNotFound If the $originalUrl could not be found
+     */
+    public function resolveRoute(string $originalUrl): RouteDefinition
+    {
+        foreach ($this->routes as $route) {
+            /** @var Url $routeOriginalUrl */
+            $routeOriginalUrl = $route->originalUrl();
+
+            if ($routeOriginalUrl->matches(Url::fromString($originalUrl))) {
+                return $route;
+            }
+        }
+
+        throw new RouteNotFound(\sprintf(
+            'Route "%s" could not be found.',
+            $originalUrl
+        ));
+    }
+}

--- a/Route/RouteResolverFactory.php
+++ b/Route/RouteResolverFactory.php
@@ -39,8 +39,13 @@ final class RouteResolverFactory
 
     public function createResolver(): RouteResolver
     {
+        $platformRoutes = [];
+        if ($this->config->isAvailable()) {
+            $platformRoutes = $this->config->routes;
+        }
+
         $routes = [];
-        foreach ($this->config->routes as $resolvedUrl => $route) {
+        foreach ($platformRoutes as $resolvedUrl => $route) {
             switch ($route['type']) {
                 case 'redirect':
                     $routes[] = new PlatformshRedirectRoute($resolvedUrl, $route);

--- a/Route/RouteResolverFactory.php
+++ b/Route/RouteResolverFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+use Platformsh\ConfigReader\Config;
+
+final class RouteResolverFactory
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    public function createResolver(): RouteResolver
+    {
+        $routes = [];
+        foreach ($this->config->routes as $resolvedUrl => $route) {
+            switch ($route['type']) {
+                case 'redirect':
+                    $routes[] = new PlatformshRedirectRoute($resolvedUrl, $route);
+                    break;
+                case 'upstream':
+                    $routes[] = new PlatformshUpstreamRoute($resolvedUrl, $route);
+                    break;
+            }
+        }
+
+        return new RouteResolver(new RouteCollection(...$routes));
+    }
+}

--- a/Route/UpstreamRoute.php
+++ b/Route/UpstreamRoute.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Route;
+
+interface UpstreamRoute extends RouteDefinition
+{
+    /**
+     * The upstream app name.
+     */
+    public function upstream(): string;
+}

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
             "prepare-web-dir": false
         },
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         },
         "patches": {
             "helhum/typo3-console": {

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,15 @@
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6.2",
         "helhum/typo3-console": "4.7.0",
+        "platformsh/config-reader": "^0.0.1",
+        "spatie/url": "^1.2",
         "symfony/symfony": "^3.3",
-        "typo3/cms": "8.7.6"
+        "typo3/cms": "8.7.6",
+        "webmozart/assert": "^1.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.5"
+        "friendsofphp/php-cs-fixer": "^2.5",
+        "phpspec/phpspec": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,7 @@
+formatter.name: pretty
+
+suites:
+    contest:
+        namespace: Bartacus\Bundle\PlatformshBundle\
+        psr4_prefix: Bartacus\Bundle\PlatformshBundle\
+        src_path: .

--- a/spec/Route/LocalUpstreamRouteSpec.php
+++ b/spec/Route/LocalUpstreamRouteSpec.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace spec\Bartacus\Bundle\PlatformshBundle\Route;
+
+use Bartacus\Bundle\PlatformshBundle\Route\LocalUpstreamRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteDefinition;
+use Bartacus\Bundle\PlatformshBundle\Route\UpstreamRoute;
+use PhpSpec\ObjectBehavior;
+use Spatie\Url\Url;
+
+final class LocalUpstreamRouteSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $originalUrl = 'https://{default}/';
+        $route = [
+            '.local_url' => 'https://dev-project.test/',
+            'type' => 'upstream',
+            'upstream' => 'app:http',
+        ];
+
+        $this->beConstructedWith($originalUrl, $route);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(LocalUpstreamRoute::class);
+    }
+
+    public function it_implements_definitions(): void
+    {
+        $this->shouldImplement(RouteDefinition::class);
+        $this->shouldImplement(UpstreamRoute::class);
+    }
+
+    public function it_returns_original_url(): void
+    {
+        $this->originalUrl()->shouldBeLike(Url::fromString('https://{default}/'));
+    }
+
+    public function it_returns_resolved_url(): void
+    {
+        $this->resolvedUrl()->shouldBeLike(Url::fromString('https://dev-project.test/'));
+    }
+
+    public function it_returns_upstream(): void
+    {
+        $this->upstream()->shouldReturn('app');
+    }
+
+    public function it_fails_with_wrong_type(): void
+    {
+        $originalUrl = 'http://{default}/';
+        $route = [
+            'local_url' => 'http://dev-project.test/',
+            'type' => 'redirect',
+            'to' => 'https://{default}/',
+        ];
+
+        $this->beConstructedWith($originalUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_fails_with_missing_local_url(): void
+    {
+        $originalUrl = 'https://{default}/';
+        $route = [
+            'type' => 'upstream',
+            'upstream' => 'app:http',
+        ];
+
+        $this->beConstructedWith($originalUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_fails_with_missing_upstream(): void
+    {
+        $originalUrl = 'https://{default}/';
+        $route = [
+            'type' => 'upstream',
+        ];
+
+        $this->beConstructedWith($originalUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+}

--- a/spec/Route/PlatformshRedirectRouteSpec.php
+++ b/spec/Route/PlatformshRedirectRouteSpec.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace spec\Bartacus\Bundle\PlatformshBundle\Route;
+
+use Bartacus\Bundle\PlatformshBundle\Route\PlatformshRedirectRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RedirectRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteDefinition;
+use PhpSpec\ObjectBehavior;
+use Spatie\Url\Url;
+
+final class PlatformshRedirectRouteSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $resolvedUrl = 'http://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'original_url' => 'http://{default}/',
+            'type' => 'redirect',
+            'to' => 'https://develop-sr3snxi-projectid.eu.platform.sh/',
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(PlatformshRedirectRoute::class);
+    }
+
+    public function it_implements_definitions(): void
+    {
+        $this->shouldImplement(RouteDefinition::class);
+        $this->shouldImplement(RedirectRoute::class);
+    }
+
+    public function it_returns_original_url(): void
+    {
+        $this->originalUrl()->shouldBeLike(Url::fromString('http://{default}/'));
+    }
+
+    public function it_returns_resolved_url(): void
+    {
+        $this->resolvedUrl()->shouldBeLike(Url::fromString('http://develop-sr3snxi-projectid.eu.platform.sh/'));
+    }
+
+    public function it_returns_to(): void
+    {
+        $this->to()->shouldBeLike(Url::fromString('https://develop-sr3snxi-projectid.eu.platform.sh/'));
+    }
+
+    public function it_fails_with_wrong_type(): void
+    {
+        $resolvedUrl = 'https://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'upstream' => 'app',
+            'original_url' => 'https://{default}/',
+            'ssi' => [
+                'enabled' => false,
+            ],
+            'type' => 'upstream',
+            'cache' => [
+                'headers' => [
+                    'Accept',
+                    'Accept-Language',
+                ],
+                'cookies' => [
+                    '*',
+                ],
+                'enabled' => false,
+                'default_ttl' => 0,
+            ],
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_fails_with_missing_original_url(): void
+    {
+        $resolvedUrl = 'http://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'type' => 'redirect',
+            'to' => 'https://develop-sr3snxi-projectid.eu.platform.sh/',
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_fails_with_missing_to(): void
+    {
+        $resolvedUrl = 'http://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'original_url' => 'http://{default}/',
+            'type' => 'redirect',
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+}

--- a/spec/Route/PlatformshUpstreamRouteSpec.php
+++ b/spec/Route/PlatformshUpstreamRouteSpec.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace spec\Bartacus\Bundle\PlatformshBundle\Route;
+
+use Bartacus\Bundle\PlatformshBundle\Route\PlatformshUpstreamRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteDefinition;
+use Bartacus\Bundle\PlatformshBundle\Route\UpstreamRoute;
+use PhpSpec\ObjectBehavior;
+use Spatie\Url\Url;
+
+final class PlatformshUpstreamRouteSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $resolvedUrl = 'https://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'upstream' => 'app',
+            'original_url' => 'https://{default}/',
+            'ssi' => [
+                'enabled' => false,
+            ],
+            'type' => 'upstream',
+            'cache' => [
+                'headers' => [
+                    'Accept',
+                    'Accept-Language',
+                ],
+                'cookies' => [
+                    '*',
+                ],
+                'enabled' => false,
+                'default_ttl' => 0,
+            ],
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(PlatformshUpstreamRoute::class);
+    }
+
+    public function it_implements_definitions(): void
+    {
+        $this->shouldImplement(RouteDefinition::class);
+        $this->shouldImplement(UpstreamRoute::class);
+    }
+
+    public function it_returns_original_url(): void
+    {
+        $this->originalUrl()->shouldBeLike(Url::fromString('https://{default}/'));
+    }
+
+    public function it_returns_resolved_url(): void
+    {
+        $this->resolvedUrl()->shouldBeLike(Url::fromString('https://develop-sr3snxi-projectid.eu.platform.sh/'));
+    }
+
+    public function it_returns_upstream(): void
+    {
+        $this->upstream()->shouldReturn('app');
+    }
+
+    public function it_fails_with_wrong_type(): void
+    {
+        $resolvedUrl = 'http://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'original_url' => 'http://{default}/',
+            'type' => 'redirect',
+            'to' => 'https://develop-sr3snxi-projectid.eu.platform.sh/',
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_fails_with_missing_original_url(): void
+    {
+        $resolvedUrl = 'https://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'upstream' => 'app',
+            'ssi' => [
+                'enabled' => false,
+            ],
+            'type' => 'upstream',
+            'cache' => [
+                'headers' => [
+                    'Accept',
+                    'Accept-Language',
+                ],
+                'cookies' => [
+                    '*',
+                ],
+                'enabled' => false,
+                'default_ttl' => 0,
+            ],
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_fails_with_missing_upstream(): void
+    {
+        $resolvedUrl = 'https://develop-sr3snxi-projectid.eu.platform.sh/';
+        $route = [
+            'original_url' => 'https://{default}/',
+            'ssi' => [
+                'enabled' => false,
+            ],
+            'type' => 'upstream',
+            'cache' => [
+                'headers' => [
+                    'Accept',
+                    'Accept-Language',
+                ],
+                'cookies' => [
+                    '*',
+                ],
+                'enabled' => false,
+                'default_ttl' => 0,
+            ],
+        ];
+
+        $this->beConstructedWith($resolvedUrl, $route);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+}

--- a/spec/Route/RouteCollectionSpec.php
+++ b/spec/Route/RouteCollectionSpec.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace spec\Bartacus\Bundle\PlatformshBundle\Route;
+
+use Bartacus\Bundle\PlatformshBundle\Route\PlatformshRedirectRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\PlatformshUpstreamRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RedirectRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteCollection;
+use Bartacus\Bundle\PlatformshBundle\Route\UpstreamRoute;
+use PhpSpec\ObjectBehavior;
+use Webmozart\Assert\Assert;
+
+class RouteCollectionSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $routes = [
+            'http://develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'original_url' => 'http://{default}/',
+                'type' => 'redirect',
+                'to' => 'https://develop-sr3snxi-projectid.eu.platform.sh/',
+            ],
+            'https://develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'upstream' => 'app',
+                'original_url' => 'https://{default}/',
+                'ssi' => [
+                    'enabled' => false,
+                ],
+                'type' => 'upstream',
+                'cache' => [
+                    'headers' => [
+                        'Accept',
+                        'Accept-Language',
+                    ],
+                    'cookies' => [
+                        '*',
+                    ],
+                    'enabled' => false,
+                    'default_ttl' => 0,
+                ],
+            ],
+            'http://www.develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'original_url' => 'http://www.{default}/',
+                'type' => 'redirect',
+                'to' => 'https://www.develop-sr3snxi-projectid.eu.platform.sh/',
+            ],
+            'https://www.develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'upstream' => 'app',
+                'original_url' => 'https://www.{default}/',
+                'ssi' => [
+                    'enabled' => false,
+                ],
+                'type' => 'upstream',
+                'cache' => [
+                    'headers' => [
+                        'Accept',
+                        'Accept-Language',
+                    ],
+                    'cookies' => [
+                        '*',
+                    ],
+                    'enabled' => false,
+                    'default_ttl' => 0,
+                ],
+            ],
+        ];
+
+        $routeObjects = [];
+        foreach ($routes as $resolvedUrl => $route) {
+            switch ($route['type']) {
+                case 'redirect':
+                    $routeObjects[] = new PlatformshRedirectRoute($resolvedUrl, $route);
+                    break;
+                case 'upstream':
+                    $routeObjects[] = new PlatformshUpstreamRoute($resolvedUrl, $route);
+                    break;
+            }
+        }
+
+        $this->beConstructedWith(...$routeObjects);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RouteCollection::class);
+    }
+
+    public function it_is_iterable(): void
+    {
+        $this->shouldImplement(\IteratorAggregate::class);
+        $this->getIterator()->shouldImplement(\Iterator::class);
+    }
+
+    public function it_returns_upstream_routes_only(): void
+    {
+        $this->getUpstreamRoutes()->shouldReturnAnInstanceOf(RouteCollection::class);
+        Assert::allIsInstanceOf($this->getWrappedObject()->getUpstreamRoutes(), UpstreamRoute::class);
+    }
+
+    public function it_returns_redirect_routes_only(): void
+    {
+        $this->getRedirectRoutes()->shouldReturnAnInstanceOf(RouteCollection::class);
+        Assert::allIsInstanceOf($this->getWrappedObject()->getRedirectRoutes(), RedirectRoute::class);
+    }
+}

--- a/spec/Route/RouteResolverFactorySpec.php
+++ b/spec/Route/RouteResolverFactorySpec.php
@@ -96,6 +96,13 @@ final class RouteResolverFactorySpec extends ObjectBehavior
         ;
     }
 
+    public function it_does_not_fail_on_empty_environment(): void
+    {
+        $this->beConstructedWith(new Config([]));
+
+        $this->createResolver()->shouldBeLike(new RouteResolver(new RouteCollection()));
+    }
+
     /**
      * @param mixed $value
      */

--- a/spec/Route/RouteResolverFactorySpec.php
+++ b/spec/Route/RouteResolverFactorySpec.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace spec\Bartacus\Bundle\PlatformshBundle\Route;
+
+use Bartacus\Bundle\PlatformshBundle\Route\PlatformshUpstreamRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteCollection;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteResolver;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory;
+use PhpSpec\ObjectBehavior;
+use Platformsh\ConfigReader\Config;
+
+final class RouteResolverFactorySpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $mockEnv = [
+            'PLATFORM_ENVIRONMENT' => 'develop',
+            'PLATFORM_ROUTES' => $this->encode([
+                'https://www.develop-sr3snxi-projectid.eu.platform.sh/' => [
+                    'upstream' => 'app',
+                    'original_url' => 'https://www.{default}/',
+                    'ssi' => [
+                        'enabled' => false,
+                    ],
+                    'type' => 'upstream',
+                    'cache' => [
+                        'headers' => [
+                            'Accept',
+                            'Accept-Language',
+                        ],
+                        'cookies' => [
+                            '*',
+                        ],
+                        'enabled' => false,
+                        'default_ttl' => 0,
+                    ],
+                ],
+            ]),
+        ];
+
+        $this->beConstructedWith(new Config($mockEnv));
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RouteResolverFactory::class);
+    }
+
+    public function it_creates_resolver(): void
+    {
+        $this->createResolver()
+            ->shouldBeLike(new RouteResolver(
+                new RouteCollection(
+                    new PlatformshUpstreamRoute('https://www.develop-sr3snxi-projectid.eu.platform.sh/', [
+                        'upstream' => 'app',
+                        'original_url' => 'https://www.{default}/',
+                        'ssi' => [
+                            'enabled' => false,
+                        ],
+                        'type' => 'upstream',
+                        'cache' => [
+                            'headers' => [
+                                'Accept',
+                                'Accept-Language',
+                            ],
+                            'cookies' => [
+                                '*',
+                            ],
+                            'enabled' => false,
+                            'default_ttl' => 0,
+                        ],
+                    ])
+                )
+            ))
+        ;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function encode($value): string
+    {
+        return \base64_encode(\json_encode($value));
+    }
+}

--- a/spec/Route/RouteResolverSpec.php
+++ b/spec/Route/RouteResolverSpec.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace spec\Bartacus\Bundle\PlatformshBundle\Route;
+
+use Bartacus\Bundle\PlatformshBundle\Exception\RouteNotFound;
+use Bartacus\Bundle\PlatformshBundle\Route\PlatformshRedirectRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\PlatformshUpstreamRoute;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteCollection;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteResolver;
+use PhpSpec\ObjectBehavior;
+
+final class RouteResolverSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $routes = [
+            'http://develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'original_url' => 'http://{default}/',
+                'type' => 'redirect',
+                'to' => 'https://develop-sr3snxi-projectid.eu.platform.sh/',
+            ],
+            'https://develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'upstream' => 'app',
+                'original_url' => 'https://{default}/',
+                'ssi' => [
+                    'enabled' => false,
+                ],
+                'type' => 'upstream',
+                'cache' => [
+                    'headers' => [
+                        'Accept',
+                        'Accept-Language',
+                    ],
+                    'cookies' => [
+                        '*',
+                    ],
+                    'enabled' => false,
+                    'default_ttl' => 0,
+                ],
+            ],
+            'http://www.develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'original_url' => 'http://www.{default}/',
+                'type' => 'redirect',
+                'to' => 'https://www.develop-sr3snxi-projectid.eu.platform.sh/',
+            ],
+            'https://www.develop-sr3snxi-projectid.eu.platform.sh/' => [
+                'upstream' => 'app',
+                'original_url' => 'https://www.{default}/',
+                'ssi' => [
+                    'enabled' => false,
+                ],
+                'type' => 'upstream',
+                'cache' => [
+                    'headers' => [
+                        'Accept',
+                        'Accept-Language',
+                    ],
+                    'cookies' => [
+                        '*',
+                    ],
+                    'enabled' => false,
+                    'default_ttl' => 0,
+                ],
+            ],
+        ];
+
+        $routeObjects = [];
+        foreach ($routes as $resolvedUrl => $route) {
+            switch ($route['type']) {
+                case 'redirect':
+                    $routeObjects[] = new PlatformshRedirectRoute($resolvedUrl, $route);
+                    break;
+                case 'upstream':
+                    $routeObjects[] = new PlatformshUpstreamRoute($resolvedUrl, $route);
+                    break;
+            }
+        }
+
+        $this->beConstructedWith(new RouteCollection(...$routeObjects));
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RouteResolver::class);
+    }
+
+    public function it_resolves_route(): void
+    {
+        $this->resolveRoute('https://www.{default}/')
+            ->shouldBeLike(
+                new PlatformshUpstreamRoute('https://www.develop-sr3snxi-projectid.eu.platform.sh/', [
+                    'upstream' => 'app',
+                    'original_url' => 'https://www.{default}/',
+                    'ssi' => [
+                        'enabled' => false,
+                    ],
+                    'type' => 'upstream',
+                    'cache' => [
+                        'headers' => [
+                            'Accept',
+                            'Accept-Language',
+                        ],
+                        'cookies' => [
+                            '*',
+                        ],
+                        'enabled' => false,
+                        'default_ttl' => 0,
+                    ],
+                ])
+            )
+        ;
+    }
+
+    public function it_resolves_route_not_found_exception(): void
+    {
+        $this->shouldThrow(RouteNotFound::class)->during('resolveRoute', ['https://doesnt.exist/'])
+        ;
+    }
+}

--- a/spec/Route/RouteResolverSpec.php
+++ b/spec/Route/RouteResolverSpec.php
@@ -25,6 +25,7 @@ namespace spec\Bartacus\Bundle\PlatformshBundle\Route;
 
 use Bartacus\Bundle\PlatformshBundle\Exception\RouteDomainNotFound;
 use Bartacus\Bundle\PlatformshBundle\Exception\RouteNotFound;
+use Bartacus\Bundle\PlatformshBundle\Route\LocalUpstreamRoute;
 use Bartacus\Bundle\PlatformshBundle\Route\PlatformshRedirectRoute;
 use Bartacus\Bundle\PlatformshBundle\Route\PlatformshUpstreamRoute;
 use Bartacus\Bundle\PlatformshBundle\Route\RouteCollection;
@@ -133,6 +134,19 @@ final class RouteResolverSpec extends ObjectBehavior
         ;
     }
 
+    public function it_resolves_local_route(): void
+    {
+        $route = new LocalUpstreamRoute('https://{default}/', [
+            '.local_url' => 'https://dev-project.test/',
+            'type' => 'upstream',
+            'upstream' => 'app:http',
+        ]);
+
+        $this->beConstructedWith(new RouteCollection($route));
+
+        $this->resolveRoute('https://{default}/')->shouldBeLike($route);
+    }
+
     public function it_resolves_route_not_found_exception(): void
     {
         $this->shouldThrow(RouteNotFound::class)->during('resolveRoute', ['https://doesnt.exist/'])
@@ -235,6 +249,19 @@ final class RouteResolverSpec extends ObjectBehavior
         $this->resolveDomain('{default}')->shouldReturn('develop-sr3snxi-projectid.eu.platform.sh');
         $this->resolveDomain('login.{default}')->shouldReturn('login.develop-sr3snxi-projectid.eu.platform.sh');
         $this->resolveDomain('idp.{default}')->shouldReturn('idp.develop-sr3snxi-projectid.eu.platform.sh');
+    }
+
+    public function it_resolves_local_domain(): void
+    {
+        $route = new LocalUpstreamRoute('https://{default}/', [
+            '.local_url' => 'https://dev-project.test/',
+            'type' => 'upstream',
+            'upstream' => 'app:http',
+        ]);
+
+        $this->beConstructedWith(new RouteCollection($route));
+
+        $this->resolveDomain('{default}')->shouldReturn('dev-project.test');
     }
 
     public function it_resolves_domain_not_found_exception(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #1
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

This adds a route resolver service which can resolve routes keys and domain likes from platform routes into the current environment URLs/domains. It also operators with `.local_url` in the local `.platform/routes.yaml` as fallback if no `$PLATFORM_ROUTES` is present (local development).