### PR TITLE
Add sys_domain updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ composer.phar
 vendor/
 
 ### PHP CS Fixer
-.php_cs.cache
+*.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
-$finder = PhpCsFixer\Finder::create()
+$commonFinder = PhpCsFixer\Finder::create()
     ->exclude('vendor')
     ->in(__DIR__)
 ;
@@ -45,43 +45,52 @@ You should have received a copy of the GNU General Public License
 along with this bundle. If not, see <http://www.gnu.org/licenses/>.
 EOF;
 
+$commonRules = [
+    '@Symfony' => true,
+    '@PHP71Migration' => true,
+    '@DoctrineAnnotation' => true,
+    'align_multiline_comment' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'combine_consecutive_unsets' => true,
+    'general_phpdoc_annotation_remove' => ['author', 'package', 'subpackage'],
+    'header_comment' => ['header' => $header],
+    'heredoc_to_nowdoc' => true,
+    'linebreak_after_opening_tag' => true,
+    'list_syntax' => ['syntax' => 'short'],
+    'mb_str_functions' => true,
+    'native_function_invocation' => true,
+    'no_null_property_initialization' => true,
+    'no_php4_constructor' => true,
+    'no_superfluous_elseif' => true,
+    'no_unneeded_curly_braces' => true,
+    'no_unneeded_final_method' => true,
+    'no_unreachable_default_argument_value' => true,
+    'no_useless_else' => true,
+    'no_useless_return' => true,
+    'ordered_class_elements' => true,
+    'ordered_imports' => true,
+    'php_unit_strict' => true,
+    'phpdoc_add_missing_param_annotation' => true,
+    'phpdoc_order' => true,
+    'phpdoc_types_order' => [
+        'null_adjustment' => 'always_last',
+        'sort_algorithm' => 'none',
+    ],
+    'semicolon_after_instruction' => true,
+    'strict_comparison' => true,
+    'strict_param' => true,
+];
+
+$finder = clone $commonFinder;
+$finder
+    // no declare and use statements allowed, because of cache concatenation
+    // so we have to ignore thus files and check them separately.
+    ->notPath('ext_localconf.php')
+    ->notPath('ext_tables.php')
+;
+
 return PhpCsFixer\Config::create()
-    ->setRules([
-        '@Symfony' => true,
-        '@PHP71Migration' => true,
-        '@DoctrineAnnotation' => true,
-        'align_multiline_comment' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'combine_consecutive_unsets' => true,
-        'declare_strict_types' => true,
-        'general_phpdoc_annotation_remove' => ['author', 'package', 'subpackage'],
-        'header_comment' => ['header' => $header],
-        'heredoc_to_nowdoc' => true,
-        'linebreak_after_opening_tag' => true,
-        'list_syntax' => ['syntax' => 'short'],
-        'mb_str_functions' => true,
-        'native_function_invocation' => true,
-        'no_null_property_initialization' => true,
-        'no_php4_constructor' => true,
-        'no_superfluous_elseif' => true,
-        'no_unneeded_curly_braces' => true,
-        'no_unneeded_final_method' => true,
-        'no_unreachable_default_argument_value' => true,
-        'no_useless_else' => true,
-        'no_useless_return' => true,
-        'ordered_class_elements' => true,
-        'ordered_imports' => true,
-        'php_unit_strict' => true,
-        'phpdoc_add_missing_param_annotation' => true,
-        'phpdoc_order' => true,
-        'phpdoc_types_order' => [
-            'null_adjustment' => 'always_last',
-            'sort_algorithm' => 'none',
-        ],
-        'semicolon_after_instruction' => true,
-        'strict_comparison' => true,
-        'strict_param' => true,
-    ])
+    ->setRules($commonRules + ['declare_strict_types' => true])
     ->setRiskyAllowed(true)
     ->setFinder($finder)
     ->setUsingCache(true)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ install: travis_retry composer update --prefer-dist
 script:
   # PHP CS Fixer
   - CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
-  - if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then IFS=$'\n' EXTRA_ARGS=('--path-mode=intersection' '--' ${CHANGED_FILES[@]}); fi
+  - if ! echo "${CHANGED_FILES}" | grep -qE "^((\\.typo3)?\\.php_cs(\\.dist)?|composer\\.lock)$"; then IFS=$'\n' EXTRA_ARGS=('--path-mode=intersection' '--' ${CHANGED_FILES[@]}); fi
   - vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no "${EXTRA_ARGS[@]}"
+  - vendor/bin/php-cs-fixer fix --config=.typo3.php_cs -v --dry-run --stop-on-violation --using-cache=no "${EXTRA_ARGS[@]}"
 
   # phpSpec
   - vendor/bin/phpspec run -f progress

--- a/.typo3.php_cs
+++ b/.typo3.php_cs
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+use PhpCsFixer\Finder;
+
+/**
+ * This is a special fixer for fixing ext_localconf.php and ext_tables.php
+ * files which require special handling because of the cache concatenation.
+ */
+require __DIR__.'/.php_cs';
+
+/* @var Finder $finder */
+$finder = clone $commonFinder;
+$finder
+    // our special files we are fixing
+    ->path('ext_localconf.php')
+    ->path('ext_tables.php')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules($commonRules)
+    ->setRiskyAllowed(true)
+    ->setFinder($finder)
+    ->setUsingCache(true)
+    ->setCacheFile('.typo3.php_cs.cache')
+    ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Install this bundle as TYPO3 extension
 
+### Fixed
+- Add TYPO3 override to extend sys_domain.domainName to 255 chars to allow longer platform.sh domains
+
 ## [1.0.2] - 2017-09-19
 ### Changed
 - Change license to GPL-3.0+, because we include TYPO3 code in future

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Resolve routes.yaml route key like domain into their environment domain
 - Read local .platform/routes.yaml if no $PLATFORM_ROUTES is available (upstream routes only)
 - Add a platform.sh route domain name to sys_domain records
+- Add domain:adapt command to TYPO3_Console to adapt sys_domain records to the current environment
 
 ### Changed
 - Install this bundle as TYPO3 extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Resolve routes.yaml route key like domain into their environment domain
 - Read local .platform/routes.yaml if no $PLATFORM_ROUTES is available (upstream routes only)
 
+### Changed
+- Install this bundle as TYPO3 extension
+
 ## [1.0.2] - 2017-09-19
 ### Changed
 - Change license to GPL-3.0+, because we include TYPO3 code in future

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add RouteResolver to resolve platform.sh routes into their environment URLs
 - Resolve routes.yaml route key like domain into their environment domain
 - Read local .platform/routes.yaml if no $PLATFORM_ROUTES is available (upstream routes only)
+- Add a platform.sh route domain name to sys_domain records
 
 ### Changed
 - Install this bundle as TYPO3 extension

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Bartacus\BartacusPlatformsh\Command\DomainCommandController;
+use Helhum\Typo3Console\Core\Booting\RunLevel;
+
+return [
+    'controllers' => [
+        DomainCommandController::class,
+    ],
+    'runLevels' => [
+        'bartacus_platformsh:domain:*' => RunLevel::LEVEL_FULL,
+    ],
+    'bootingSteps' => [],
+];

--- a/Configuration/TCA/Overrides/sys_domain.php
+++ b/Configuration/TCA/Overrides/sys_domain.php
@@ -21,4 +21,33 @@ declare(strict_types=1);
  * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 $GLOBALS['TCA']['sys_domain']['columns']['domainName']['config']['max'] = 255;
+
+//<editor-fold desc="Add a route domain name field" defaultstate="collapsed">
+$routeDomainName = [
+    'tx_bartacusplatformsh_routeDomainName' => [
+        'label' => 'Platform.sh Route Domain:',
+        'config' => [
+            'type' => 'input',
+            'size' => 35,
+            'max' => 255,
+            'eval' => 'required,unique,lower,trim,domainname',
+            'softref' => 'substitute',
+        ],
+    ],
+];
+
+ExtensionManagementUtility::addTCAcolumns('sys_domain', $routeDomainName);
+
+$GLOBALS['TCA']['sys_domain']['palettes']['domainName'] = [
+    'showitem' => 'domainName, tx_bartacusplatformsh_routeDomainName,',
+];
+
+$GLOBALS['TCA']['sys_domain']['types']['1']['showitem'] = \str_replace(
+    'domainName',
+    '--palette--;;domainName',
+    $GLOBALS['TCA']['sys_domain']['types']['1']['showitem']
+);
+//</editor-fold>

--- a/Configuration/TCA/Overrides/sys_domain.php
+++ b/Configuration/TCA/Overrides/sys_domain.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$GLOBALS['TCA']['sys_domain']['columns']['domainName']['config']['max'] = 255;

--- a/Configuration/TCA/Overrides/sys_domain.php
+++ b/Configuration/TCA/Overrides/sys_domain.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
  * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use Bartacus\Bundle\PlatformshBundle\Evaluation\PlatformshDomainNameEvaluator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 $GLOBALS['TCA']['sys_domain']['columns']['domainName']['config']['max'] = 255;
@@ -33,7 +34,7 @@ $routeDomainName = [
             'type' => 'input',
             'size' => 35,
             'max' => 255,
-            'eval' => 'required,unique,lower,trim,domainname',
+            'eval' => 'required,unique,lower,trim,'.PlatformshDomainNameEvaluator::class,
             'softref' => 'substitute',
         ],
     ],

--- a/Evaluation/PlatformshDomainNameEvaluator.php
+++ b/Evaluation/PlatformshDomainNameEvaluator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\Evaluation;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class PlatformshDomainNameEvaluator
+{
+    /**
+     * Evaluation of 'platformsh_domainname'-type values.
+     * Special handling for domains with {default} placeholder.
+     *
+     * @param string $value Value to evaluate
+     *
+     * @return string An ASCII encoded (punicode) string
+     */
+    public function evaluateFieldValue(string $value): string
+    {
+        // looks a bit flaky, but IMHO no one will ever use PSHDEFAULT in a route.
+        $value = \str_replace('{default}', 'PSHDEFAULT', $value);
+
+        if (!\preg_match('/^[a-z0-9.\\-]*$/i', $value)) {
+            $value = GeneralUtility::idnaEncode($value);
+        }
+
+        $value = \str_replace('PSHDEFAULT', '{default}', $value);
+
+        return $value;
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,5 +16,12 @@
         <service id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolver" public="true">
             <factory service="Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory" method="createResolver" />
         </service>
+
+        <service id="Bartacus\BartacusPlatformsh\Command\DomainCommandController">
+            <call method="setRouteResolver">
+                <argument type="service" id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolver" />
+            </call>
+            <tag name="bartacus.make_instance" />
+        </service>
     </services>
 </container>

--- a/TYPO3Command/DomainCommandController.php
+++ b/TYPO3Command/DomainCommandController.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\BartacusPlatformsh\Command;
+
+use Bartacus\Bundle\PlatformshBundle\Exception\RouteDomainNotFound;
+use Bartacus\Bundle\PlatformshBundle\Route\RouteResolver;
+use Helhum\Typo3Console\Mvc\Controller\CommandController;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Reflection\ReflectionService;
+
+class DomainCommandController extends CommandController
+{
+    /**
+     * @var ReflectionService
+     */
+    protected $reflectionService;
+
+    /**
+     * @var RouteResolver
+     */
+    private $routeResolver;
+
+    public function injectReflectionService(ReflectionService $reflectionService): void
+    {
+        $this->reflectionService = $reflectionService;
+    }
+
+    public function setRouteResolver(RouteResolver $routeResolver): void
+    {
+        $this->routeResolver = $routeResolver;
+    }
+
+    /**
+     * Adapts the domain records to the platform.sh environment.
+     */
+    public function adaptCommand(): void
+    {
+        $domains = $this->findDomainsWithRouteDomainName();
+
+        $domainCount = \count($domains);
+        if (!$domainCount) {
+            $this->outputLine('<warning>Could not find any domain records to adapt. Did you forget to create one or to configure the platform.sh route domain name?');
+
+            return;
+        }
+
+        $this->outputLine(\sprintf(
+            '<info>Found %d domains to adapt.</info>',
+            $domainCount
+        ));
+
+        foreach ($domains as $domain) {
+            $routeDomainName = $domain['tx_bartacusplatformsh_routeDomainName'];
+
+            try {
+                $newDomainName = $this->routeResolver->resolveDomain($routeDomainName);
+                $this->updateDomain($routeDomainName, $newDomainName);
+
+                $this->outputLine(\sprintf(
+                    'Adapted platform.sh route domain name "%s" to domain name "%s".',
+                    $routeDomainName,
+                    $newDomainName
+                ));
+            } catch (RouteDomainNotFound $e) {
+                $this->outputLine(\sprintf(
+                    '<warning>Could not find matching route for platform.sh route domain name "%s".</warning>',
+                    $routeDomainName
+                ));
+            }
+        }
+    }
+
+    private function findDomainsWithRouteDomainName(): iterable
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_domain')
+        ;
+
+        $qb->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+        ;
+
+        $domains = $qb
+            ->select('uid', 'domainName', 'tx_bartacusplatformsh_routeDomainName')
+            ->from('sys_domain')
+            ->where(
+                $qb->expr()->neq(
+                    'tx_bartacusplatformsh_routeDomainName',
+                    $qb->createNamedParameter('')
+                )
+            )
+            ->execute()
+            ->fetchAll()
+        ;
+
+        return $domains;
+    }
+
+    private function updateDomain(string $routeDomainName, string $newDomainName): void
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_domain')
+        ;
+
+        $qb->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+        ;
+
+        $qb->update('sys_domain')
+            ->where(
+                $qb->expr()->eq(
+                    'tx_bartacusplatformsh_routeDomainName',
+                    $qb->createNamedParameter($routeDomainName)
+                )
+            )
+            ->set('domainName', $newDomainName)
+            ->execute()
+        ;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Bartacus\\Bundle\\PlatformshBundle\\": ""
+            "Bartacus\\Bundle\\PlatformshBundle\\": "",
+            "Bartacus\\BartacusPlatformsh\\Command\\": "TYPO3Command/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bartacus/platformsh-bundle",
-    "type": "symfony-bundle",
-    "description": "Support bundle for using Platform.sh together with Bartacus",
+    "type": "typo3-cms-extension",
+    "description": "Support bundle for using Platform.sh together with Bartacus and TYPO3",
     "keywords": [ "typo3", "symfony", "framework", "integration", "platform.sh" ],
     "license": "GPL-3.0+",
     "authors": [
@@ -27,6 +27,9 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.5",
         "phpspec/phpspec": "^4.0"
+    },
+    "replace": {
+        "bartacus_platformsh": "self.version"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "bartacus/bartacus-bundle": "^1.0",
         "cweagans/composer-patches": "^1.6.2",
         "helhum/typo3-console": "4.7.0",
         "platformsh/config-reader": "^0.0.1",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Bartacus Platform.sh Bundle',
+    'description' => 'Support bundle for using Platform.sh together with Bartacus and TYPO§3',
+    'category' => 'Base',
+    'author' => 'Patrik Karisch',
+    'author_email' => 'patrik@karisch.guru',
+    'state' => 'stable',
+    'version' => '1.1.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '8.7.0-',
+        ],
+    ],
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+if ('BE' === \TYPO3_MODE) {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][\Bartacus\Bundle\PlatformshBundle\Evaluation\PlatformshDomainNameEvaluator::class] = '';
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,3 +1,4 @@
 CREATE TABLE sys_domain (
-    domainName VARCHAR(255) NOT NULL DEFAULT ''
+    domainName                            VARCHAR(255) NOT NULL DEFAULT '',
+    tx_bartacusplatformsh_routeDomainName VARCHAR(255) NOT NULL DEFAULT ''
 );

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,3 @@
+CREATE TABLE sys_domain (
+    domainName VARCHAR(255) NOT NULL DEFAULT ''
+);

--- a/spec/Evaluation/PlatformshDomainNameEvaluatorSpec.php
+++ b/spec/Evaluation/PlatformshDomainNameEvaluatorSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) 2017 Patrik Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace spec\Bartacus\Bundle\PlatformshBundle\Evaluation;
+
+use Bartacus\Bundle\PlatformshBundle\Evaluation\PlatformshDomainNameEvaluator;
+use PhpSpec\ObjectBehavior;
+
+class PlatformshDomainNameEvaluatorSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(PlatformshDomainNameEvaluator::class);
+    }
+
+    public function it_works_on_normal_route(): void
+    {
+        $this->evaluateFieldValue('www.example.com')->shouldReturn('www.example.com');
+    }
+
+    public function it_works_on_normal_punnycode_route(): void
+    {
+        $this->evaluateFieldValue('點看.example.com')->shouldReturn('xn--c1yn36f.example.com');
+    }
+
+    public function it_works_on_default_route(): void
+    {
+        $this->evaluateFieldValue('www.{default}')->shouldReturn('www.{default}');
+    }
+
+    public function it_works_on_default_punnycode_route(): void
+    {
+        $this->evaluateFieldValue('點看.{default}')->shouldReturn('xn--c1yn36f.{default}');
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #3
| Related issues/PRs | #1, #2
| License | GPL-3.0+

#### What's in this PR?

This adds a TYPO3_Console command `domain:adapt` to adapt the sys_domain records domainName field according "Platform.sh Route Domain Name" of the current environment.

As downside to modify TCA and SQL this bundle get's now installed as TYPO3 extension :(

Also includes a temporary TYPO3 fix for https://forge.typo3.org/issues/82515 until this is released in a new TYPO3 version.