### PR TITLE
Update config reader and add credential formatter

### DIFF
--- a/BartacusPlatformshBundle.php
+++ b/BartacusPlatformshBundle.php
@@ -23,8 +23,14 @@ declare(strict_types=1);
 
 namespace Bartacus\Bundle\PlatformshBundle;
 
+use Bartacus\Bundle\PlatformshBundle\DependencyInjection\Compiler\CredentialFormatterPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class BartacusPlatformshBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new CredentialFormatterPass());
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - New `typo3_mysql` credential formatter for easy formatting of the typo3 database connection
+- Allow to register your own credential formatter with the DI tag `bartacus.platformsh.credential_formatter`
 
 ### Breaking
 - Updated to use `platformsh/config-reader` @ `^2.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- New `typo3_mysql` credential formatter for easy formatting of the typo3 database connection
+
 ### Breaking
 - Updated to use `platformsh/config-reader` @ `^2.1`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - New `typo3_mysql` credential formatter for easy formatting of the typo3 database connection
 - Allow to register your own credential formatter with the DI tag `bartacus.platformsh.credential_formatter`
+- Auto configure `bartacus.platformsh.credential_formatter` with interface `CredentialFormatterInterface`
 
 ### Breaking
 - Updated to use `platformsh/config-reader` @ `^2.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Breaking
+- Updated to use `platformsh/config-reader` @ `^2.1`
 
 ## [2.0.1] - 2019-04-10
 ### Fixed

--- a/CredentialFormatter/CredentialFormatterInterface.php
+++ b/CredentialFormatter/CredentialFormatterInterface.php
@@ -23,31 +23,16 @@ declare(strict_types=1);
 
 namespace Bartacus\Bundle\PlatformshBundle\CredentialFormatter;
 
-class DatabaseCredentialFormatter implements CredentialFormatterInterface
+/**
+ * A CredentialFormatter knows itself which formatters are supported and registered.
+ */
+interface CredentialFormatterInterface
 {
-    public static function getFormatters(): array
-    {
-        return [
-            'typo3_mysql' => 'formatMysql',
-        ];
-    }
-
-    public function formatMysql(array $credentials): array
-    {
-        return \array_merge([
-            'driver' => 'mysqli',
-            'charset' => 'utf8mb4',
-        ], $this->formatCredentials($credentials));
-    }
-
-    private function formatCredentials(array $credentials): array
-    {
-        return [
-            'host' => $credentials['host'],
-            'port' => $credentials['port'],
-            'dbname' => $credentials['path'],
-            'user' => $credentials['username'],
-            'password' => $credentials['password'],
-        ];
-    }
+    /**
+     * Returns an array of formatter name and the callable to use.
+     *
+     * The array keys are the formatter names and the value can be
+     * the method name to call.
+     */
+    public static function getFormatters(): array;
 }

--- a/CredentialFormatter/DatabaseCredentialFormatter.php
+++ b/CredentialFormatter/DatabaseCredentialFormatter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) Emily Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\CredentialFormatter;
+
+class DatabaseCredentialFormatter
+{
+    public static function formatMysql(array $credentials): array
+    {
+        return array_merge([
+            'driver' => 'mysqli',
+            'charset' => 'utf8mb4',
+        ], self::formatCredentials($credentials));
+    }
+
+    private static function formatCredentials(array $credentials): array
+    {
+        return [
+            'host' => $credentials['host'],
+            'port' => $credentials['port'],
+            'dbname' => $credentials['path'],
+            'user' => $credentials['username'],
+            'password' => $credentials['password'],
+        ];
+    }
+}

--- a/DependencyInjection/BartacusPlatformshExtension.php
+++ b/DependencyInjection/BartacusPlatformshExtension.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Bartacus\Bundle\PlatformshBundle\DependencyInjection;
 
+use Bartacus\Bundle\PlatformshBundle\DependencyInjection\Compiler\CredentialFormatterPass;
 use Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -45,6 +46,10 @@ class BartacusPlatformshExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $this->registerPlatformRoutesConfig($container, $config);
+
+        $container->registerForAutoconfiguration(CredentialFormatterPass::class)
+            ->addTag('bartacus.platformsh.credential_formatter')
+        ;
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container): Configuration

--- a/DependencyInjection/Compiler/CredentialFormatterPass.php
+++ b/DependencyInjection/Compiler/CredentialFormatterPass.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus Platform.sh bundle.
+ *
+ * Copyright (c) Emily Karisch
+ *
+ * This bundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This bundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this bundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\PlatformshBundle\DependencyInjection\Compiler;
+
+use Bartacus\Bundle\PlatformshBundle\CredentialFormatter\CredentialFormatterInterface;
+use Platformsh\ConfigReader\Config;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CredentialFormatterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has(Config::class)) {
+            return;
+        }
+
+        $definition = $container->findDefinition(Config::class);
+
+        $taggedServices = $container->findTaggedServiceIds('bartacus.platformsh.credential_formatter', true);
+
+        foreach ($taggedServices as $id => $tags) {
+            $def = $container->getDefinition($id);
+
+            // We must assume that the class value has been correctly filled, even if the service is created by a factory
+            $class = $def->getClass();
+
+            if (!$r = $container->getReflectionClass($class)) {
+                throw new InvalidArgumentException(\sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
+            }
+
+            if (!$r->isSubclassOf(CredentialFormatterInterface::class)) {
+                throw new InvalidArgumentException(\sprintf('Service "%s" must implement interface "%s".', $id, CredentialFormatterInterface::class));
+            }
+
+            /** @var CredentialFormatterInterface $class */
+            $class = $r->name;
+            foreach ($class::getFormatters() as $name => $method) {
+                $args = [$name, [new Reference($id), $method]];
+                $definition->addMethodCall('registerFormatter', $args);
+            }
+        }
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,7 +4,15 @@
         xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Platformsh\ConfigReader\Config" public="true" />
+        <service id="Platformsh\ConfigReader\Config" public="true">
+            <call method="registerFormatter">
+                <argument>typo3_mysql</argument>
+                <argument type="collection">
+                    <argument>Bartacus\Bundle\PlatformshBundle\CredentialFormatter\DatabaseCredentialFormatter</argument>
+                    <argument>formatMysql</argument>
+                </argument>
+            </call>
+        </service>
 
         <service id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory">
             <argument type="service" id="Platformsh\ConfigReader\Config" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,14 +4,9 @@
         xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Platformsh\ConfigReader\Config" public="true">
-            <call method="registerFormatter">
-                <argument>typo3_mysql</argument>
-                <argument type="collection">
-                    <argument>Bartacus\Bundle\PlatformshBundle\CredentialFormatter\DatabaseCredentialFormatter</argument>
-                    <argument>formatMysql</argument>
-                </argument>
-            </call>
+        <service id="Platformsh\ConfigReader\Config" public="true" />
+        <service id="Bartacus\Bundle\PlatformshBundle\CredentialFormatter\DatabaseCredentialFormatter">
+            <tag name="bartacus.platformsh.credential_formatter" />
         </service>
 
         <service id="Bartacus\Bundle\PlatformshBundle\Route\RouteResolverFactory">

--- a/Resources/doc/config-reader.rst
+++ b/Resources/doc/config-reader.rst
@@ -1,0 +1,10 @@
+=============
+Config Reader
+=============
+
+This bundle requires the ``platformsh/config-reader`` (see https://github.com/platformsh/config-reader-php) and is usable for requiring your database, solr or redis configs.
+
+Dependency Injection
+====================
+
+The ``Platformsh\ConfigReader\Config`` class is existent as public service, please use this service instead of initializing a new instance of the config reader every time you need it.

--- a/Resources/doc/config-reader.rst
+++ b/Resources/doc/config-reader.rst
@@ -8,3 +8,12 @@ Dependency Injection
 ====================
 
 The ``Platformsh\ConfigReader\Config`` class is existent as public service, please use this service instead of initializing a new instance of the config reader every time you need it.
+
+Credential Formatter
+====================
+
+Beside the default `credential formatters`_ provided by the config readers, this bundle provides the following additional config readers:
+
+    * ``typo3_mysql`` provides the connection array to configure a TYPO3 database connection for MySQL or MariaDB.
+
+.. _`credential formatters`: https://github.com/platformsh/config-reader-php#formatting-service-credentials

--- a/Resources/doc/config-reader.rst
+++ b/Resources/doc/config-reader.rst
@@ -16,4 +16,40 @@ Beside the default `credential formatters`_ provided by the config readers, this
 
     * ``typo3_mysql`` provides the connection array to configure a TYPO3 database connection for MySQL or MariaDB.
 
+Create your own credential formatter
+------------------------------------
+
+You can add your own credential formatters to the config reader by implementing the ``CredentialFormatterInterface`` and returning an array of formatter name as key and the method name as value in the static ``getFormatters()`` method. Example:
+
+.. code-block:: php
+
+    <?php
+
+    namespace App/CredentialFormatter
+
+    class SolrCredentialFormatter implements CredentialFormatterInterface
+    {
+        public static function getFormatters(): array
+        {
+            return [
+                'typo3_solr' => 'formatSolrConnection',
+            ];
+        }
+
+        public function formatSolrConnection(array $credentials): array
+        {
+            return [
+                // ...
+            ]
+        }
+    }
+
+Tag your credential formatter service with ``bartacus.platformsh.credential_formatter`` and it's registered. Example:
+
+.. code-block:: yaml
+
+    services:
+        App/CredentialFormatter/SolrCredentialFormatter:
+            tags: ['bartacus.platformsh.credential_formatter']
+
 .. _`credential formatters`: https://github.com/platformsh/config-reader-php#formatting-service-credentials

--- a/Resources/doc/config-reader.rst
+++ b/Resources/doc/config-reader.rst
@@ -52,4 +52,6 @@ Tag your credential formatter service with ``bartacus.platformsh.credential_form
         App/CredentialFormatter/SolrCredentialFormatter:
             tags: ['bartacus.platformsh.credential_formatter']
 
+If you have auto configure activated, your credential formatter will be automatically registered as one, without any configuration needed.
+
 .. _`credential formatters`: https://github.com/platformsh/config-reader-php#formatting-service-credentials

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -16,4 +16,5 @@ Contents
     :maxdepth: 2
 
     getting-started/index
+    config-reader
     route-resolver

--- a/Route/RouteResolverFactory.php
+++ b/Route/RouteResolverFactory.php
@@ -46,7 +46,7 @@ final class RouteResolverFactory
     public function createResolver(): RouteResolver
     {
         $routes = [];
-        if ($this->config->isAvailable()) {
+        if ($this->config->inRuntime()) {
             $routes = $this->readPlatformRoutes();
         } elseif (null !== $this->platformshRoutesConfig) {
             $routes = $this->readLocalRoutes();
@@ -58,7 +58,7 @@ final class RouteResolverFactory
     private function readPlatformRoutes(): iterable
     {
         $routes = [];
-        foreach ($this->config->routes as $resolvedUrl => $route) {
+        foreach ($this->config->routes() as $resolvedUrl => $route) {
             switch ($route['type']) {
                 case 'redirect':
                     $routes[] = new PlatformshRedirectRoute($resolvedUrl, $route);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "bartacus/bartacus-bundle": "^2.0",
         "cweagans/composer-patches": "^1.6.5",
         "helhum/typo3-console": "^5.6",
-        "platformsh/config-reader": "^1.0",
+        "platformsh/config-reader": "^2.1",
         "spatie/url": "^1.2",
         "symfony/config": "^4.2",
         "symfony/dependency-injection": "^4.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

* Uses new platformsh/config-reader major version
* Adds credential formatter `typo3_mysql`
* Auto configure own credential formatters